### PR TITLE
Add on/off switch for WS

### DIFF
--- a/Example/AtlasSupportSDK/TabBarViewController.swift
+++ b/Example/AtlasSupportSDK/TabBarViewController.swift
@@ -36,7 +36,6 @@ class TabBarController: UITabBarController {
             UINavigationController(rootViewController: homeViewController)
         ]
         
-        let appId = "a95uw0hfsr"
         if let atlassViewController = AtlasSDK.getAtlassViewController() {
             atlassViewController.tabBarItem = UITabBarItem(title: "Online help",
                                                            image: UIImage(systemName: "message.circle"),

--- a/Sources/AtlasSDK.swift
+++ b/Sources/AtlasSDK.swift
@@ -12,6 +12,8 @@ public class AtlasSDK {
     /// The appId is empty by default and must
     /// be set before using getAtlasViewController() or any other public methods.
     internal static var appId: String = ""
+    /// See AtlasWebSocketService `connect` function for  isWebSocketDisabled usage
+    internal static var isWebSocketDisabled: Bool = false
     private static var viewController: AtlasViewController?
     
     private static let atlasUserService = AtlasUserService()
@@ -60,6 +62,14 @@ public class AtlasSDK {
                     userName: userName,
                     userEmail: userEmail)
         }
+    }
+    
+    static func setWebSocketDisabled() {
+        isWebSocketDisabled = true
+    }
+    
+    static func setWebSocketEnabled() {
+        isWebSocketDisabled = false
     }
     
 /// Coming in future versions

--- a/Sources/Services/WebSocket/AtlasWebSocketService.swift
+++ b/Sources/Services/WebSocket/AtlasWebSocketService.swift
@@ -31,6 +31,8 @@ class AtlasWebSocketService: NSObject, WebSocketConnection, URLSessionWebSocketD
     private let webSocketMessageParser = AtlasWebSocketMessageParser()
     
     func connect(atlasId: String) {
+        if AtlasSDK.isWebSocketDisabled { return }
+        
         var urlComponents = URLComponents()
         urlComponents.scheme = AtlasNetworkURLs.ATLAS_WEB_SOCKET_SCHEME
         urlComponents.host = AtlasNetworkURLs.ATLAS_WEB_SOCKET_BASE_URL


### PR DESCRIPTION
The idea to give an opportunity (for developers/users) to disable WebSocket connection if they don't use this functionality and save device resources (battery/network).

Additionally, we can provide public method to fetch user's unread messages. This will be alternative for projects that don't want to relay on web socket. 